### PR TITLE
Add dependency for streamlit share usage

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
       - matplotlib>=3.3.4
       - altair>=4.1.0
       - streamlit==1.3.1
+      - protobuf==3.20.*
       - dash==1.19.0
       - jupyter==1.0.0
       - biopython==1.78


### PR DESCRIPTION
Streamlit share has updated internal dependencies which crash this app.

Proposed changes enforce that a working `protobuf` version is present